### PR TITLE
Fps logic

### DIFF
--- a/src/group4/game/Main.java
+++ b/src/group4/game/Main.java
@@ -75,13 +75,21 @@ public class Main implements Runnable {
         // Set the clear color
         glClearColor(1.0f, 0.0f, 0.0f, 0.0f);
 
+        timer = new Timer();
+        boolean render = true;
         // Run the rendering loop until the user has attempted to close
         // the window or has pressed the ESCAPE key.
         while ( !glfwWindowShouldClose(window) ) {
+            while (timer.getDeltaTime() >= timer.getFrameTime()) {
+                timer.nextFrame();
+                render = true;
+            }
 
-
-            glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT); // clear the framebuffer
-            glfwSwapBuffers(window); // swap the color buffers
+            if (render) {
+                glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT); // clear the framebuffer
+                glfwSwapBuffers(window); // swap the color buffers
+                render = false;
+            }
 
             // Poll for window events. The key callback above will only be
             // invoked during this call.

--- a/src/group4/game/Timer.java
+++ b/src/group4/game/Timer.java
@@ -1,33 +1,86 @@
+package group4.game;
+
 public class Timer {
-    private int FPS;
-    private double frameTime;
+    private int targetFPS; // The target targetFPS
+    private double frameTime; // The target frame time, 1/targetFPS
 
-    private double timeUnprocessed;
-    private double timePassed;
+    private double deltaTime; // The time we're running behind since last update
 
-    private int counter;
+    private int frameCounter; // How many frames we render each second
+    private double elapsedTime; // For tracking the second.
 
     private double currentTime;
     private double previousTime;
 
+    /**
+     * Initializations via the constructor
+     */
     public Timer() {
-        FPS = 60;
-        frameTime = 1.0 / (double) FPS;
-        previousTime = 0.0;
-        timePassed = 0.0;
-        counter = 0;
-        timeUnprocessed = 0;
+        targetFPS = 60;
+        frameTime = 1.0 / (double) targetFPS;
+
+        deltaTime = 0.0;
+
+        frameCounter = 0;
+        elapsedTime = 0.0;
+
+        previousTime = this.getTime(); // NOW is the starting time for the timer
     }
 
+    /**
+     * Gets the time difference between a current call and the previous call, and keeps track of
+     * the total time we are running behind on running the target targetFPS. (So we don't skip frames)
+     *
+     * Additionally tracks the total time elapsed since the last measuring point for the targetFPS the
+     * game actually achieves.
+     *
+     * @return double, the total time we are running behind true 60FPS.
+     */
     public double getDeltaTime() {
-        currentTime = (double) System.nanoTime() / (double) 1000000000L;
-        double delta = previousTime - currentTime;
+        // Find delta since last update
+        currentTime = this.getTime();
+        double delta = currentTime - previousTime;
         previousTime = currentTime;
-        timePassed += delta;
-        return delta;
+
+        deltaTime += delta;   // Add it to the time we're behind
+        elapsedTime += delta; // Add it to the time since last measuring point
+        return deltaTime;
     }
 
+    /**
+     * Calling nextFrame() indicates to the timer that the Game handled a frame.
+     * I.e. the total time we were running behind was larger than the time for a single frame, hence
+     * the Game will process another frame, and we're decreasing the time we're running behind.
+     */
     public void nextFrame() {
-        counter++;
+        deltaTime -= frameTime; // Reduce the deltaTime with the amount of time a single frame should take
+        frameCounter++;         // Keep track of the number of frames we rendered since last measurement
+
+        // If the elapsedTime at this point is greater than 1.0 second, then the frameCounter is our new
+        // measurement for the actual targetFPS we obtain.
+        if (elapsedTime >= 1.0) {
+            // TODO: As we do not have any visual debug utils yet, we print. Change this in the future
+            //       to be a visual overlay on the game.
+            System.out.println("Real FPS: " + frameCounter); // Log
+
+            elapsedTime = 0;
+            frameCounter = 0;
+        }
+    }
+
+    /**
+     * Gives back 1.0 / targetFPS.
+     * @return double, the intended time delta between two frames.
+     */
+    public double getFrameTime() {
+        return this.frameTime;
+    }
+
+    /**
+     * Gives the current system time as a double.
+     * @return double, the current system time.
+     */
+    private double getTime() {
+        return (double) System.nanoTime() / (double) 1000000000L;
     }
 }


### PR DESCRIPTION
This should take care of some initial FPS issues. Within Timer you specify the `targetFPS` (perhaps configurable later on), and the class keeps track of the actual FPS we achieve. This also doesn't skip frames, if you're system can't achieve the targetFPS (60), then I believe the game runs slower without skipping frames. It should however not be able to run faster than the targetFPS (unless you freeze the game temporarily e.g. by resizing the window, then it will play catch-up).

Later on the game-loop could perhaps be made into something more async-like which would keep the logic pumping at the targetFPS, but pump out the frames slower. Though this will probably suffice for our goals right now.

As with the Window class, the Timer class its location is temporary untill we decide a better spot.

Timer outputs the actual fps to the console for now. Later this should be a debug overlay.