### PR TITLE
Abstract dying system

### DIFF
--- a/src/group4/ECS/systems/DyingSystem.java
+++ b/src/group4/ECS/systems/DyingSystem.java
@@ -1,0 +1,42 @@
+package group4.ECS.systems;
+
+import com.badlogic.ashley.core.Entity;
+import com.badlogic.ashley.core.Family;
+import com.badlogic.ashley.systems.IteratingSystem;
+import group4.ECS.etc.TheEngine;
+
+/**
+ * Abstract class for processing death of an entity.
+ */
+public abstract class DyingSystem extends IteratingSystem {
+
+    DyingSystem(Family f) {
+        super(f);
+    }
+
+    @Override
+    protected void processEntity(Entity entity, float deltaTime) {
+        if (shouldDie(entity, deltaTime)) {
+            die(entity, deltaTime);
+            TheEngine.getInstance().removeEntity(entity);
+        }
+    }
+
+    /**
+     * Condition of death
+     * @param e the entity whose fate is determined
+     * @param deltaTime frame speed
+     * @return whether entity should be removed from the engine.
+     */
+    protected abstract boolean shouldDie (Entity e, float deltaTime);
+
+    /**
+     * Callback for death of the entity
+     * Note, that this method does not need to remove from the engine,
+     * it is done within processEntity, after this method.
+     * @param e entity to kill
+     * @param deltaTime frame speed
+     */
+    protected abstract void die (Entity e, float deltaTime);
+
+}


### PR DESCRIPTION
Considering we will have different callbacks and conditions of death for a different type of entities, I thought that using an abstract class will be useful, to avoid duplicate code and to keep the structure consistent throughout other dying systems.