### PR TITLE
urgent collision change

### DIFF
--- a/src/group4/ECS/components/CollisionComponent.java
+++ b/src/group4/ECS/components/CollisionComponent.java
@@ -2,6 +2,7 @@ package group4.ECS.components;
 
 import com.badlogic.ashley.core.Component;
 import com.badlogic.ashley.core.Entity;
+import group4.ECS.systems.collision.CollisionData;
 import group4.ECS.systems.collision.CollisionHandlers.AbstractCollisionHandler;
 
 import java.util.HashSet;
@@ -14,7 +15,7 @@ public class CollisionComponent implements Component {
      * entity is added to this list. When the collision with that entity is process, that entity is removed
      * from this list again.
      */
-    public Set<Entity> collisions;
+    public Set<CollisionData> collisions;
 
     public AbstractCollisionHandler handler;
 

--- a/src/group4/ECS/systems/collision/CollisionData.java
+++ b/src/group4/ECS/systems/collision/CollisionData.java
@@ -1,0 +1,38 @@
+package group4.ECS.systems.collision;
+
+import com.badlogic.ashley.core.Entity;
+import group4.maths.Vector3f;
+
+public class CollisionData {
+
+    // the entity that is being collided with
+    public Entity entity;
+
+    /**
+     * the vector that needs to be added to the position entity that owns this collision data to make sure it
+     * does not intersect with entity
+     */
+    public Vector3f displacement;
+
+    /**
+     * Creates new CollisionData.
+     *
+     * @param entity       entity which collides with the owner of this collision data.
+     * @param displacement vector that needs to be added to the owners position to prevent the collision.
+     */
+    public CollisionData(Entity entity, Vector3f displacement) {
+        this.entity = entity;
+        this.displacement = displacement;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        // only allow one collision per entity
+        if (o instanceof CollisionData) {
+            CollisionData cd = (CollisionData) o;
+            return entity.equals(cd.entity);
+        }
+
+        return super.equals(o);
+    }
+}

--- a/src/group4/ECS/systems/collision/CollisionHandlers/PlayerCollision.java
+++ b/src/group4/ECS/systems/collision/CollisionHandlers/PlayerCollision.java
@@ -6,8 +6,8 @@ import group4.ECS.entities.Player;
 import group4.ECS.entities.items.weapons.Bullet;
 import group4.ECS.entities.mobs.Mob;
 import group4.ECS.etc.Mappers;
+import group4.ECS.systems.collision.CollisionData;
 
-import java.util.Collection;
 import java.util.Set;
 
 
@@ -20,9 +20,10 @@ public class PlayerCollision extends AbstractCollisionHandler<Player> {
 
     @Override
     public void collision(Player player, CollisionComponent cc) {
-        Set<Entity> others = cc.collisions;
+        Set<CollisionData> others = cc.collisions;
         // loop through all collisions and handle them accordingly
-        for (Entity other : others) {
+        for (CollisionData cd : others) {
+            Entity other = cd.entity;
             // example
             if (other instanceof Mob) {
                 handleMob(player, (Mob) other);

--- a/src/group4/ECS/systems/collision/CollisionSystem.java
+++ b/src/group4/ECS/systems/collision/CollisionSystem.java
@@ -8,6 +8,7 @@ import group4.ECS.components.CollisionComponent;
 import group4.ECS.etc.Families;
 import group4.ECS.etc.Mappers;
 import group4.ECS.etc.TheEngine;
+import group4.maths.Vector3f;
 
 /**
  * This applies collision to entities that can move and have a bounding box
@@ -42,19 +43,128 @@ public class CollisionSystem extends IteratingSystem {
             }
 
             // get the intersection between this (moving collidable entity) and other (collidable entity)
-            Rectangle intersection = UncollidingSystem.getIntersectingRectangle(e, other);
+            Rectangle intersection = getIntersectingRectangle(e, other);
 
             // if there is no intersection, do nothing
             if (intersection == null) {
                 continue;
             }
 
+            // Get displacement vector
+            Vector3f displacement = processCollision(e, other);
+
             CollisionComponent occ = Mappers.collisionMapper.get(other);
             // add the collision to both entities
-            cc.collisions.add(other);
-            occ.collisions.add(e);
+            CollisionData c1 = new CollisionData(other, displacement);
+            CollisionData c2 = new CollisionData(e, displacement.scale(-1.0f));
+            cc.collisions.add(c1);
+            occ.collisions.add(c2);
         }
 
     }
 
+    /// BELOW ARE FUNCTIONS TO DEAL WITH AXIS ALIGNED RECTANGLE INTERSECTION
+    // TODO: maybe move those around a bit since there will also be functions to deal with spline intersection
+
+
+    /**
+     * Produces a displacement vector for a possibly occuring collision
+     *
+     * @param first the entityto possibly move in case of collision
+     * @param scnd  the other entity that is not moved
+     * @return
+     */
+    static Vector3f processCollision(Entity first, Entity scnd) {
+        // get positions
+        Vector3f firstPos = Mappers.positionMapper.get(first).position;
+        Vector3f scndPos = Mappers.positionMapper.get(scnd).position;
+        // get the intersection rectangle
+        Rectangle intersection = getIntersectingRectangle(first, scnd);
+        if (intersection == null) return new Vector3f();
+        // displace according to the rectangle
+        if (intersection.height <= intersection.width) { // TODO: consider y collision from top
+            return new Vector3f(0, intersection.height, 0);
+        }
+        // move in the correct x direction
+        if (firstPos.x > scndPos.x) {
+            return new Vector3f(intersection.width, 0, 0);
+        }
+        return new Vector3f(-1 * intersection.width, 0, 0);
+    }
+
+    /**
+     * Produces an rectangle representing the intersecting area
+     *
+     * @param rectangle1 first rectangle
+     * @param rectangle2 second rectangle
+     * @return the rectangle which is common for rectangle1 and rectangle2
+     * @throws IllegalArgumentException if pre is violated
+     * @pre rectangle1.overlaps(rectangle2)
+     */
+    static public Rectangle intersect(Rectangle rectangle1, Rectangle rectangle2) throws IllegalArgumentException {
+        if (!rectangle1.overlaps(rectangle2)) {
+            throw new IllegalArgumentException("Attempted to get the intersecting rectangle from two non-intersecting rectangles. \n" +
+                    "Rectangle 1: " + rectangle1.toString() + " \n" +
+                    "Rectangle 2: " + rectangle2.toString());
+        }
+        // https://stackoverflow.com/questions/17267221/libgdx-get-intersection-rectangle-from-rectangle-overlaprectangle
+        Rectangle intersection = new Rectangle();
+        intersection.x = Math.max(rectangle1.x, rectangle2.x);
+        intersection.width = Math.min(rectangle1.x + rectangle1.width, rectangle2.x + rectangle2.width) - intersection.x;
+        intersection.y = Math.max(rectangle1.y, rectangle2.y);
+        intersection.height = Math.min(rectangle1.y + rectangle1.height, rectangle2.y + rectangle2.height) - intersection.y;
+        return intersection;
+    }
+
+
+    /**
+     * Given information about a bounding boxes, determine whether they collide
+     *
+     * @param firstPos bottom left of first bb
+     * @param firstDim dimensions of first bb
+     * @param scndPos  bottom left of second bb
+     * @param scndDim  dimensions of second bb
+     * @return whether bounding boxes collide in XY
+     */
+    static public boolean collide(Vector3f firstPos, Vector3f firstDim,
+                                  Vector3f scndPos, Vector3f scndDim) {
+        // define bounding boxes
+        Rectangle firstBB = bbAsRectangle(firstPos, firstDim);
+        Rectangle scndBB = bbAsRectangle(scndPos, scndDim);
+        // if doesnt overlap, no displacement
+        return firstBB.overlaps(scndBB);
+    }
+
+    /**
+     * Determines whether two collidable entities colide
+     *
+     * @return whether first collides with sceond
+     */
+    static public boolean collide(Entity first, Entity second) {
+        // get positions
+        Vector3f firstPos = Mappers.positionMapper.get(first).position;
+        Vector3f scndPos = Mappers.positionMapper.get(second).position;
+        // get dimensions
+        Vector3f firstDim = Mappers.dimensionMapper.get(first).dimension;
+        Vector3f scndDim = Mappers.dimensionMapper.get(second).dimension;
+        return collide(firstPos, firstDim, scndPos, scndDim);
+    }
+
+    public static Rectangle getIntersectingRectangle(Entity first, Entity second) {
+        if (!collide(first, second)) {
+            return null;
+        }
+        // get positions
+        Vector3f firstPos = Mappers.positionMapper.get(first).position;
+        Vector3f scndPos = Mappers.positionMapper.get(second).position;
+        // get dimensions
+        Vector3f firstDim = Mappers.dimensionMapper.get(first).dimension;
+        Vector3f scndDim = Mappers.dimensionMapper.get(second).dimension;
+        return intersect(bbAsRectangle(firstPos, firstDim),
+                bbAsRectangle(scndPos, scndDim));
+    }
+
+    private static Rectangle bbAsRectangle(Vector3f botLeft, Vector3f dim) {
+        return new Rectangle(botLeft.x, botLeft.y, dim.x, dim.y);
+    }
 }

--- a/src/group4/ECS/systems/collision/UncollidingSystem.java
+++ b/src/group4/ECS/systems/collision/UncollidingSystem.java
@@ -39,10 +39,12 @@ public class UncollidingSystem extends IteratingSystem {
         MovementComponent mc = Mappers.movementMapper.get(e);
         // get all entities that i collide with
         CollisionComponent cc = Mappers.collisionMapper.get(e);
-        for (Entity other : cc.collisions) {
-            if (other == e) continue;
+        for (CollisionData cd : cc.collisions) {
+            Entity other = cd.entity;
+            if (other.equals(e)) continue;
             // get the displacement vector
-            Vector3f colDim = processCollision(e, other);
+            Vector3f colDim = cd.displacement;
+
             // if x and y collisions already happened break out
             mc.velocity.addi(colDim);
             // cap the velocity (for safety)
@@ -56,102 +58,7 @@ public class UncollidingSystem extends IteratingSystem {
         cc.collisions.clear();
     }
 
-    /**
-     * Produces a displacement vector for a possibly occuring collision
-     *
-     * @param first the entityto possibly move in case of collision
-     * @param scnd  the other entity that is not moved
-     * @return
-     */
-    Vector3f processCollision(Entity first, Entity scnd) {
-        // get positions
-        Vector3f firstPos = Mappers.positionMapper.get(first).position;
-        Vector3f scndPos = Mappers.positionMapper.get(scnd).position;
-        // get the intersection rectangle
-        Rectangle intersection = UncollidingSystem.getIntersectingRectangle(first, scnd);
-        if (intersection == null) return new Vector3f();
-        // displace according to the rectangle
-        if (intersection.height <= intersection.width) { // TODO: consider y collision from top
-            return new Vector3f(0, intersection.height, 0);
-        }
-        // move in the correct x direction
-        if (firstPos.x > scndPos.x) {
-            return new Vector3f(intersection.width, 0, 0);
-        }
-        return new Vector3f(-1 * intersection.width, 0, 0);
-    }
 
-    /**
-     * Produces an rectangle representing the intersecting area
-     *
-     * @param rectangle1 first rectangle
-     * @param rectangle2 second rectangle
-     * @return the rectangle which is common for rectangle1 and rectangle2
-     * @throws IllegalArgumentException if pre is violated
-     * @pre rectangle1.overlaps(rectangle2)
-     */
-    static public Rectangle intersect(Rectangle rectangle1, Rectangle rectangle2) throws IllegalArgumentException {
-        if (!rectangle1.overlaps(rectangle2)) {
-            throw new IllegalArgumentException("Attempted to get the intersecting rectangle from two non-intersecting rectangles. \n" +
-                    "Rectangle 1: " + rectangle1.toString() + " \n" +
-                    "Rectangle 2: " + rectangle2.toString());
-        }
-        // https://stackoverflow.com/questions/17267221/libgdx-get-intersection-rectangle-from-rectangle-overlaprectangle
-        Rectangle intersection = new Rectangle();
-        intersection.x = Math.max(rectangle1.x, rectangle2.x);
-        intersection.width = Math.min(rectangle1.x + rectangle1.width, rectangle2.x + rectangle2.width) - intersection.x;
-        intersection.y = Math.max(rectangle1.y, rectangle2.y);
-        intersection.height = Math.min(rectangle1.y + rectangle1.height, rectangle2.y + rectangle2.height) - intersection.y;
-        return intersection;
-    }
-
-
-    /**
-     * Given information about a bounding boxes, determine whether they collide
-     *
-     * @param firstPos bottom left of first bb
-     * @param firstDim dimensions of first bb
-     * @param scndPos  bottom left of second bb
-     * @param scndDim  dimensions of second bb
-     * @return whether bounding boxes collide in XY
-     */
-    static public boolean collide(Vector3f firstPos, Vector3f firstDim,
-                                  Vector3f scndPos, Vector3f scndDim) {
-        // define bounding boxes
-        Rectangle firstBB = bbAsRectangle(firstPos, firstDim);
-        Rectangle scndBB = bbAsRectangle(scndPos, scndDim);
-        // if doesnt overlap, no displacement
-        return firstBB.overlaps(scndBB);
-    }
-
-    /**
-     * Determines whether two collidable entities colide
-     *
-     * @return whether first collides with sceond
-     */
-    static public boolean collide(Entity first, Entity second) {
-        // get positions
-        Vector3f firstPos = Mappers.positionMapper.get(first).position;
-        Vector3f scndPos = Mappers.positionMapper.get(second).position;
-        // get dimensions
-        Vector3f firstDim = Mappers.dimensionMapper.get(first).dimension;
-        Vector3f scndDim = Mappers.dimensionMapper.get(second).dimension;
-        return UncollidingSystem.collide(firstPos, firstDim, scndPos, scndDim);
-    }
-
-    public static Rectangle getIntersectingRectangle(Entity first, Entity second) {
-        if (!UncollidingSystem.collide(first, second)) {
-            return null;
-        }
-        // get positions
-        Vector3f firstPos = Mappers.positionMapper.get(first).position;
-        Vector3f scndPos = Mappers.positionMapper.get(second).position;
-        // get dimensions
-        Vector3f firstDim = Mappers.dimensionMapper.get(first).dimension;
-        Vector3f scndDim = Mappers.dimensionMapper.get(second).dimension;
-        return UncollidingSystem.intersect(bbAsRectangle(firstPos, firstDim),
-                bbAsRectangle(scndPos, scndDim));
-    }
 
     private float capDirection(float cur, float max) {
         if (max < 1e-6 && max > -1e-6) { // close to zero
@@ -164,7 +71,5 @@ public class UncollidingSystem extends IteratingSystem {
         return Math.abs(cur) / cur * Math.min(max, Math.abs(cur));
     }
 
-    private static Rectangle bbAsRectangle(Vector3f botLeft, Vector3f dim) {
-        return new Rectangle(botLeft.x, botLeft.y, dim.x, dim.y);
-    }
+
 }


### PR DESCRIPTION
Each collision component now has a set of collision data instead of a set of entities. This is to be able to store the displacement vector in there to prevent having to compute it twice and to also integrate the system with spline collision. Note that a lot of use cases of the old system have to be slightly changed. 

I would like to get this merged with everything asap to prevent having to do more rewriting.