### PR TITLE
Checkpoint improvements for AI training

### DIFF
--- a/src/group4/AI/EvolutionLogger.java
+++ b/src/group4/AI/EvolutionLogger.java
@@ -64,7 +64,7 @@ public class EvolutionLogger implements EvolutionObserver<Brain> {
     @Override
     public void populationUpdate(PopulationData<? extends Brain> data) {
         String log = String.format("Current generation: %d / %d \n Mean Fitness: %f \n Best Fitness: %f \n STD fitness: %f",
-                data.getGenerationNumber(), Evolver.genCount, data.getMeanFitness(),
+                data.getGenerationNumber() + 1, Evolver.genCount, data.getMeanFitness(),
                 data.getBestCandidateFitness(), data.getFitnessStandardDeviation());
 
         if (this.filePath != null) {
@@ -75,6 +75,9 @@ public class EvolutionLogger implements EvolutionObserver<Brain> {
         !data.isNaturalFitness() && bestFitness > data.getBestCandidateFitness()) { // found better fitness than before
             bestFitness = data.getBestCandidateFitness(); // save it in the variable
             forceSave = true; // and save the model
+        }
+        if (data.getGenerationNumber() + 1 == Evolver.genCount) {
+            forceSave = true;
         }
 
         // save best candidate every number of generations


### PR DESCRIPTION
When training, sometimes we did not save better models just because their generation number didnt apply to the conditions of checkpointing every 2 generations.

This PR fixes this by adding another condition to saving a model, which is, if it has the best fitness so far. (irrespective of current gen nr and accounting for both natural and unnatural fitness)